### PR TITLE
feat: implement code packaging and status update endpoints

### DIFF
--- a/src/code/code.controller.ts
+++ b/src/code/code.controller.ts
@@ -21,6 +21,8 @@ import { AuthGuard } from 'src/guards/auth/auth.guard';
 import { JwtType } from 'src/guards/auth/jwt.metadata';
 import { JWT_TYPE } from 'src/constants/jwt.constants';
 import { ZodValidationPipe } from 'nestjs-zod';
+import { PackCodesDto, PackedCodesResponseDto } from './dto/pack-codes.dto';
+import { UpdateCodesStatusDto } from './dto/update-codes-status.dto';
 
 @Controller('code')
 export class CodeController {
@@ -56,5 +58,36 @@ export class CodeController {
     @Body() writeBoxesCodeDto: WriteBoxesCodeDto,
   ): Promise<BoxesCodeDataDto> {
     return await this.codeService.getNextSscc(writeBoxesCodeDto);
+  }
+
+  @ApiResponse({
+    status: 201,
+    description: 'Codes successfully packed and new SSCC code created',
+    type: PackedCodesResponseDto,
+  })
+  @JwtType(JWT_TYPE.Operator)
+  @UseGuards(AuthGuard)
+  @UsePipes(ZodValidationPipe)
+  @Post('/pack')
+  @HttpCode(HttpStatus.CREATED)
+  async packCodes(
+    @Body() packCodesDto: PackCodesDto,
+  ): Promise<PackedCodesResponseDto> {
+    return await this.codeService.packCodes(packCodesDto);
+  }
+
+  @ApiResponse({
+    status: 200,
+    description: 'Codes status successfully updated',
+  })
+  @JwtType(JWT_TYPE.Operator)
+  @UseGuards(AuthGuard)
+  @UsePipes(ZodValidationPipe)
+  @Post('/update-status')
+  @HttpCode(HttpStatus.OK)
+  async updateCodesStatus(
+    @Body() updateCodesStatusDto: UpdateCodesStatusDto,
+  ): Promise<void> {
+    await this.codeService.updateCodesStatus(updateCodesStatusDto);
   }
 }

--- a/src/code/dto/pack-codes.dto.ts
+++ b/src/code/dto/pack-codes.dto.ts
@@ -1,0 +1,21 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+
+const PackCodesSchema = z.object({
+  id: z.number(),
+  ssccCode: z.string().length(18),
+  codes: z.array(z.string()),
+  shiftId: z.string(),
+  productId: z.string(),
+});
+
+export class PackCodesDto extends createZodDto(PackCodesSchema) {}
+
+const PackedCodesResponseSchema = z.object({
+  id: z.number(),
+  ssccCode: z.string(),
+});
+
+export class PackedCodesResponseDto extends createZodDto(
+  PackedCodesResponseSchema,
+) {}

--- a/src/code/dto/update-codes-status.dto.ts
+++ b/src/code/dto/update-codes-status.dto.ts
@@ -1,0 +1,11 @@
+import { createZodDto } from 'nestjs-zod';
+import { z } from 'zod';
+
+const UpdateCodesStatusSchema = z.object({
+  codes: z.array(z.string()),
+  shiftId: z.string(),
+});
+
+export class UpdateCodesStatusDto extends createZodDto(
+  UpdateCodesStatusSchema,
+) {}


### PR DESCRIPTION
- Add packCodes method that:
  - Validates input SSCC code and related codes
  - Updates individual codes status to USED and links them to box
  - Generates next SSCC code and saves it to database
  - Returns new SSCC code and ID for further operations

- Add updateCodesStatus method that:
  - Validates input shift ID and individual codes
  - Updates individual codes status to USED
  - Links codes to specified shift
  - Performs all updates in transaction for data integrity

Both methods include comprehensive error handling and logging.